### PR TITLE
修正: [SW2] 能力値作成画面の修正

### DIFF
--- a/_core/skin/sw2/making.html
+++ b/_core/skin/sw2/making.html
@@ -12,7 +12,7 @@
       技：<input type="number" name="tec">
       体：<input type="number" name="phy">
       心：<input type="number" name="spi"><br>
-      <div class="annotate small">種族が「人間（冒険者）」の場合は無視されます。</div>
+      <div class="annotate small">種族が「人間（冒険者）」「魔動天使」の場合は無視されます。</div>
     <dt>種族<dd>
       <select name="race" required>
         <option disabled selected></option>


### PR DESCRIPTION
種族が「魔動天使」の場合も生まれが無視されることを追記