### PR TITLE
修正: [SW2]「ミスティック観察」の表記をやめる

### DIFF
--- a/_core/lib/sw2/data-class.pl
+++ b/_core/lib/sw2/data-class.pl
@@ -583,7 +583,7 @@ our %class = (
     id       => 'Mys',
     eName    => 'mystic',
     package  => {
-      Obs => { name => '観察', stt => 'E' },
+      Obs => { name => '探索・天候予測', stt => 'E' },
     },
     craft => {
       jName => '占瞳',


### PR DESCRIPTION
「ミスティック探索・天候予測」とする